### PR TITLE
Updated setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
         'console_scripts': [
             'autopytoexe=auto_py_to_exe.__main__:run',
             'auto-py-to-exe=auto_py_to_exe.__main__:run'
-        ],
+        ], 'gui_scripts': [
+            'autopytoexe=auto_py_to_exe.__main__:run',
+            'auto-py-to-exe=auto_py_to_exe.__main__:run'
+        ]
     },
 )


### PR DESCRIPTION
If you are developing a GUI application (in Tkinter, PyQt/PySide, wxPython, PyGTK, PyGame…), you should change the declaration to gui_scripts. On *nix, this makes no difference, but on Windows, it means that running your script by opening the created .exe files does not show a console window. Note that stdout/stderr do not work in that mode under Windows, which can lead to spurious application crashes. (GUI-only processes cannot use stdout/stderr because they don’t have a console attached) .
I read it from 'https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/'