### PR TITLE
Add Bulgarian translations

### DIFF
--- a/README-Bulgarian.md
+++ b/README-Bulgarian.md
@@ -1,0 +1,165 @@
+<h1 align="center">Auto PY to EXE</h1>
+<p align="center">Конвертор от .py към .exe с графичен интерфейс използвайки <a href="https://pyinstaller.readthedocs.io/en/stable/index.html">PyInstaller.</a></p>
+
+<p align="center">
+    <img src="https://nitratine.net/posts/auto-py-to-exe/feature.png" alt="Empty interface">
+</p>
+
+<p align="center">
+    <a href="https://pypi.org/project/auto-py-to-exe/"><img src="https://img.shields.io/pypi/v/auto-py-to-exe.svg" alt="PyPI Version"></a>
+    <a href="https://pypi.org/project/auto-py-to-exe/"><img src="https://img.shields.io/pypi/pyversions/auto-py-to-exe.svg" alt="PyPI Supported Versions"></a>
+    <a href="https://pypi.org/project/auto-py-to-exe/"><img src="https://img.shields.io/pypi/l/auto-py-to-exe.svg" alt="License"></a>
+    <a href="https://pepy.tech/project/auto-py-to-exe"><img src="https://static.pepy.tech/badge/auto-py-to-exe/month" alt="Downloads Per Month"></a>
+    <a href="https://pyinstaller.readthedocs.io/en/stable/requirements.html"><img src="https://img.shields.io/badge/platform-windows%20%7C%20linux%20%7C%20macos-lightgrey" alt="Supported Platforms"></a>
+    <a href="https://www.buymeacoffee.com/brentvollebregt"><img src="https://img.shields.io/badge/-buy_me_a%C2%A0beer-gray?logo=buy-me-a-coffee" alt="Donate"></a>
+</p>
+
+阅读中文版的README ，点击 [这里](./README-Chinese.md)
+
+Suomenkieliset käyttöohjeet löydät [täältä](./README-Finnish.md)
+
+Türkçe Talimatları [burada](./README-Turkish.md) bulabilirsiniz.
+
+دستور العمل های [فارسی](./README-Persian.md)
+
+한국어로 된 설명은 [여기](./README-Korean.md)를 참고하세요.
+
+
+
+## Демо
+
+<p align="center">
+    <img src="https://nitratine.net/posts/auto-py-to-exe/auto-py-to-exe-demo.gif" alt="auto-py-to-exe Demo">
+</p>
+
+## За начало
+
+### Изисквания
+ - Python : 3.6-3.12
+
+*За да имате интерфейса, показан на снимките, ще ви бъде необходим браузърът Chrome. Ако Chrome не е инсталиран или е предоставена опцията --no-chrome, ще се използва браузърът по подразбиране.*
+> От версия [PyInstaller 4.0](https://github.com/pyinstaller/pyinstaller/releases/tag/v4.0) нататък, Python 2.7 вече не се поддържа. За насоки относно как да използвате този инструмент с Python 2.7, прочетете раздела "[Python 2.7 Support](#python-27-support)" по-долу.
+
+### Инсталация и начин на ползване
+#### Инсталация чрез [PyPI](https://pypi.org/project/auto-py-to-exe/)
+Може да инсталирате този проект чрез PyPI:
+```
+$ pip install auto-py-to-exe
+```
+За да го стартирате, напишете следната команда в терминалът:
+```
+$ auto-py-to-exe
+```
+
+> Ако имате повече от една версия на Python инсталирана, можете да използвате `python -m auto_py_to_exe` вместо `auto-py-to-exe`.
+
+### Инсталиране чрез [GitHub](https://github.com/brentvollebregt/auto-py-to-exe)
+```
+$ git clone https://github.com/brentvollebregt/auto-py-to-exe.git
+$ cd auto-py-to-exe
+$ python setup.py install
+```
+За да го стартирате, напишете следната команда в терминалът:
+```
+$ auto-py-to-exe
+```
+
+#### За да изпълните локално чрез [Github](https://github.com/brentvollebregt/auto-py-to-exe) (без инсталиране).
+За да го стартирате, може да направите следните стъпки:
+1. Клонирайте или изтеглете [repo](https://github.com/brentvollebregt/auto-py-to-exe)
+2. Отворете терминал и влезте в директорията
+3. Напишете ```python -m pip install -r requirements.txt```
+
+За да стартирате приложението, изпълнете командата `python -m auto_py_to_exe`. Ще се отвори прозорец на Chrome в режим на приложение с проекта, който се изпълнява вътре.
+
+Уверете се, че сте в директорията под auto_py_to_exe (там ще сте след стъпка 3), когато извиквате `python -m auto_py_to_exe`, или ще трябва да посочите папката auto_py_to_exe абсолютно/относително спрямо текущото ви местоположение.
+
+## Използване на Приложението
+1. Изберете местоположението на вашия скрипт (поставете го там или използвайте файлов мениджър)
+    - Обвивката ще стане синя, когато файлът съществува
+2. Изберете други опции и добавете неща като икона или други файлове
+3. Натиснете големият син бутон в долната част, за да конвертирате
+4. Намерете конвертираните си файлове в /output след приключване
+
+*Лесно.*
+
+### Аргументи
+Използване: `auto-py-to-exe [-nc] [-c [CONFIG]] [-o [PATH]] [filename]`
+
+| Аргумент                                                     | Тип                        | Описание                                                                                                                                                                         |
+| ------------------------------------------------------------ |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| filename                                                     | позиционен/незадължителен  | Предварително попълва полето "Местоположение на скрипта" в потребителския интерфейс.                                                                                             |
+| -nc, --no-chrome                                             | незадължителен             | Отваря потребителския интерфейс с браузъра по подразбиране (който може да бъде Chrome). Няма да се опитва да намери Chrome.                                                      |
+| -nu, --no-ui                                                 | незадължителен             | Не се опитва да отвори потребителския интерфейс в браузър и просто извежда адреса, на който приложението може да бъде достъпно.                                                  |
+| -c [CONFIG], --config [CONFIG]                               | незадължителен             | Предоставете конфигурационен файл (json), за да предварително попълните потребителския интерфейс. Тези файлове могат да бъдат генерирани в раздела "Настройки".                  |
+| -o [PATH], --output-dir [PATH]                               | незадължителен             | Задайте директорията по подразбиране за изход. Това все още може да бъде променено в интерфейса.                                                                                 |
+| -bdo [FOLDER_PATH], --build-directory-override [FOLDER_PATH] | незадължителен             | Презаписва стандартната директория за изграждане. Полезно, ако трябва да изключите дадена директория, за да предотвратите антивирусните програми от изтриване на файлове.        |
+| -lang [LANGUAGE_CODE], --language [LANGUAGE_CODE]            | незадължителен             | Указва потребителския интерфейс към коя езикова версия да се насочва по подразбиране при стартиране. Кодовете за език може да бъдат намерени в таблицата под "Преводи" по-долу.  |
+
+
+> Ако стартирате този пакет локално, ще трябва да извикате `python -m auto_py_to_exe` вместо `auto-py-to-exe`.
+
+### JSON Конфигурация
+Вместо да въвеждате едни и същи данни отново и отново в интерфейса, можете да експортирате текущото състояние, като отидете в раздела "Конфигурация" в настройките и експортирате конфигурацията в JSON файл. Тази конфигурация може после да бъде импортирана в интерфейса отново, за да попълни всички полета.
+
+Това действие за експортиране на JSON конфигурация не запазва директорията за изход автоматично, тъй като преместването на хостове може да означава различни структури на директории. Ако искате да включите директорията за изход в JSON конфигурацията, добавете я под `nonPyinstallerOptions.outputDirectory` в JSON файла (ще трябва да създадете нов ключ).
+
+## Видео
+Ако имате нужда от нещо визуално, което да ви помогне да започнете, [аз направих видео за първата версия на този проект](https://youtu.be/OZSZHmWSOeM); някои неща може да са различни, но същите концепции все още са приложими.
+
+## Проблеми при Използването на Инструмента
+Ако имате проблеми с пакетирания изпълним файл или с използването на този инструмент като цяло, ви препоръчвам да прочетете [моя блог публикация за общите проблеми при използването на auto-py-to-exe](https://nitratine.net/blog/post/issues-when-using-auto-py-to-exe/?utm_source=auto_py_to_exe&utm_medium=readme_link&utm_campaign=auto_py_to_exe_help). Тази публикация покрива нещата, които трябва да знаете за пакетирането на Python скриптове и решенията за неща, които често се объркват.
+
+Ако вярвате, че сте открили проблем с този инструмент, моля, [създайте проблем](https://github.com/brentvollebregt/auto-py-to-exe/issues/new/choose) (натиснете "Започнете") и попълнете предоставената от "Доклад за грешка" шаблон. Ако вашият проблем е свързан само с вашето приложение, моля, не създавайте проблем в този репозитори - вместо това, коментирайте в публикацията за помощ, видеото или създайте нова дискусия.
+
+> При попълване на шаблона, обърнете внимание да обясните ясно какво се случва, предоставете стъпки за възпроизвеждане и [минимален възпроизводим пример](https://stackoverflow.com/help/minimal-reproducible-example) и обяснете какво вярвате, че трябва да се случи. Без тези данни, ще отнеме повече време да идентифицираме проблема.
+
+## Преводи
+
+| Език                                        | Преводач                                                                        | Преведено                            |
+|---------------------------------------------|---------------------------------------------------------------------------------|--------------------------------------|
+| Arabic (العربية)                            | [Tayeb-Ali](https://github.com/tayeb-ali)                                       | UI                                   |
+| Brazilian Portuguese (Português Brasileiro) | [marleyas](https://github.com/marleyas), [reneoliveirajr](https://github.com/reneoliveirajr) | UI                                   |
+| Chinese Simplified (简体中文)                   | [jiangzhe11](https://github.com/jiangzhe11)                                     | UI and [README](./README-Chinese.md) |
+| Chinese Traditional (繁體中文)                  | [startgo](https://github.com/ystartgo)                                          | UI                                   |
+| Czech                                       | [Matto58](https://github.com/Matto58)                                           | UI                                   |
+| English                                     | -                                                                               | UI and README                        |
+| Finnish (Suomen kieli)                      | [ZapX5](https://github.com/ZapX5)                                               | UI and [README](./README-Finnish.md) |
+| French (Français)                           | [flaviedesp](https://github.com/flaviedesp)                                     | UI                                   |
+| German (Deutsch)                            | [hebens](https://github.com/hebens), [ackhh](https://github.com/ackhh)          | UI                                   |
+| Greek (Ελληνικά)                            | [sofronas](https://github.com/sofronas)                                         | UI                                   |
+| Indonesian (Bahasa Indonesia)               | [MarvinZhong](https://github.com/MarvinZhong)                                   | UI                                   |
+| Italian (Italiano)                          | [itsEmax64](https://github.com/itsEmax64)                                       | UI                                   |
+| Japanese (日本語)                              | [NattyanTV](https://github.com/nattyan-tv)                                      | UI                                   |
+| Korean (한국어)                                | [jhk1090](https://github.com/jhk1090)                                           | UI and [README](./README-Korean.md)  |
+| Persian (فارسی)                             | [DrunkLeen](https://github.com/drunkleen), [Ar.dst](https://github.com/Ar-dst)  | UI and [README](./README-Persian.md) |
+| Russian (Русский)                           | Oleg                                                                            | UI                                   |
+| Spanish (Español)                           | [enriiquee](https://github.com/enriiquee)                                       | UI                                   |
+| Spanish Latam (Español Latam)               | [Matyrela](https://github.com/Matyrela)                                         | UI                                   |
+| Serbian                                     | [rina](https://github.com/sweatshirts)                                          | UI                                   |
+| Thai (ภาษาไทย)                              | [teerut26](https://github.com/teerut26)                                         | UI (partial)                         |
+| Turkish (Türkçe)                            | [mcagriaksoy](https://github.com/mcagriaksoy)                                   | UI and [README](./README-Turkish.md) |
+| Ukrainian (Українська)                      | [AndrejGorodnij](https://github.com/AndrejGorodnij)                             | UI                                   |
+| Vietnamese (Tiếng Việt)                     | [7777Hecker](https://github.com/7777Hecker)                                     | UI                                   |
+| Bulgarian (Български)                       | [kbkozlev](https://github.com/kbkozlev)                                         | UI and [README](README-Bulgarian.md) |
+
+> Искате да добавите превод на друг език? Актуализирайте [i18n.js](https://github.com/brentvollebregt/auto-py-to-exe/blob/master/auto_py_to_exe/web/js/i18n.js) и представете заявка за промяна (PR) или го прикачете към проблем (issue).
+
+## Поддръжка на Python 2.7
+От [PyInstaller v4.0](https://github.com/pyinstaller/pyinstaller/releases/tag/v4.0), който бе пуснат на 9 август 2020 г., Python 2.7 вече не се поддържа; въпреки това можете да използвате този инструмент с Python 2.7, като инсталирате по-стара версия на PyInstaller. [PyInstaller v3.6](https://github.com/pyinstaller/pyinstaller/releases/tag/v3.6) беше последната версия, която поддържаше Python 2.7; за да я инсталирате, първо деинсталирайте всички налични версии на PyInstaller и след това изпълнете `python -m pip install pyinstaller==3.6`.
+
+## Тестване
+Тестовете се намират в `tests/` и се изпълняват с помощта на pytest:
+
+```
+$ pip install pytest
+$ pip install -e .
+$ pytest
+```
+
+## Screenshots
+
+| <!-- -->    | <!-- -->    |
+|-------------|-------------|
+| [![Empty interface](https://nitratine.net/posts/auto-py-to-exe/empty-interface.png)](https://nitratine.net/posts/auto-py-to-exe/empty-interface.png) | [![Filled out](https://nitratine.net/posts/auto-py-to-exe/filled-out.png)](https://nitratine.net/posts/auto-py-to-exe/filled-out.png) |
+| [![Converting](https://nitratine.net/posts/auto-py-to-exe/converting.png)](https://nitratine.net/posts/auto-py-to-exe/converting.png) | [![Completed](https://nitratine.net/posts/auto-py-to-exe/completed.png)](https://nitratine.net/posts/auto-py-to-exe/completed.png) |

--- a/README-Bulgarian.md
+++ b/README-Bulgarian.md
@@ -114,35 +114,6 @@ $ auto-py-to-exe
 
 > При попълване на шаблона, обърнете внимание да обясните ясно какво се случва, предоставете стъпки за възпроизвеждане и [минимален възпроизводим пример](https://stackoverflow.com/help/minimal-reproducible-example) и обяснете какво вярвате, че трябва да се случи. Без тези данни, ще отнеме повече време да идентифицираме проблема.
 
-## Преводи
-
-| Език                                        | Преводач                                                                        | Преведено                            |
-|---------------------------------------------|---------------------------------------------------------------------------------|--------------------------------------|
-| Arabic (العربية)                            | [Tayeb-Ali](https://github.com/tayeb-ali)                                       | UI                                   |
-| Brazilian Portuguese (Português Brasileiro) | [marleyas](https://github.com/marleyas), [reneoliveirajr](https://github.com/reneoliveirajr) | UI                                   |
-| Chinese Simplified (简体中文)                   | [jiangzhe11](https://github.com/jiangzhe11)                                     | UI and [README](./README-Chinese.md) |
-| Chinese Traditional (繁體中文)                  | [startgo](https://github.com/ystartgo)                                          | UI                                   |
-| Czech                                       | [Matto58](https://github.com/Matto58)                                           | UI                                   |
-| English                                     | -                                                                               | UI and README                        |
-| Finnish (Suomen kieli)                      | [ZapX5](https://github.com/ZapX5)                                               | UI and [README](./README-Finnish.md) |
-| French (Français)                           | [flaviedesp](https://github.com/flaviedesp)                                     | UI                                   |
-| German (Deutsch)                            | [hebens](https://github.com/hebens), [ackhh](https://github.com/ackhh)          | UI                                   |
-| Greek (Ελληνικά)                            | [sofronas](https://github.com/sofronas)                                         | UI                                   |
-| Indonesian (Bahasa Indonesia)               | [MarvinZhong](https://github.com/MarvinZhong)                                   | UI                                   |
-| Italian (Italiano)                          | [itsEmax64](https://github.com/itsEmax64)                                       | UI                                   |
-| Japanese (日本語)                              | [NattyanTV](https://github.com/nattyan-tv)                                      | UI                                   |
-| Korean (한국어)                                | [jhk1090](https://github.com/jhk1090)                                           | UI and [README](./README-Korean.md)  |
-| Persian (فارسی)                             | [DrunkLeen](https://github.com/drunkleen), [Ar.dst](https://github.com/Ar-dst)  | UI and [README](./README-Persian.md) |
-| Russian (Русский)                           | Oleg                                                                            | UI                                   |
-| Spanish (Español)                           | [enriiquee](https://github.com/enriiquee)                                       | UI                                   |
-| Spanish Latam (Español Latam)               | [Matyrela](https://github.com/Matyrela)                                         | UI                                   |
-| Serbian                                     | [rina](https://github.com/sweatshirts)                                          | UI                                   |
-| Thai (ภาษาไทย)                              | [teerut26](https://github.com/teerut26)                                         | UI (partial)                         |
-| Turkish (Türkçe)                            | [mcagriaksoy](https://github.com/mcagriaksoy)                                   | UI and [README](./README-Turkish.md) |
-| Ukrainian (Українська)                      | [AndrejGorodnij](https://github.com/AndrejGorodnij)                             | UI                                   |
-| Vietnamese (Tiếng Việt)                     | [7777Hecker](https://github.com/7777Hecker)                                     | UI                                   |
-| Bulgarian (Български)                       | [kbkozlev](https://github.com/kbkozlev)                                         | UI and [README](README-Bulgarian.md) |
-
 > Искате да добавите превод на друг език? Актуализирайте [i18n.js](https://github.com/brentvollebregt/auto-py-to-exe/blob/master/auto_py_to_exe/web/js/i18n.js) и представете заявка за промяна (PR) или го прикачете към проблем (issue).
 
 ## Поддръжка на Python 2.7

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Türkçe Talimatları [burada](./README-Turkish.md) bulabilirsiniz.
 
 한국어로 된 설명은 [여기](./README-Korean.md)를 참고하세요.
 
+Български README [тук](README-Bulgarian.md)
+
 ## Demo
 
 <p align="center">
@@ -140,6 +142,7 @@ If you believe you've found an issue with this tool, please [create an issue](ht
 | Turkish (Türkçe)                            | [mcagriaksoy](https://github.com/mcagriaksoy)                          | UI and [README](./README-Turkish.md) |
 | Ukrainian (Українська)                      | [AndrejGorodnij](https://github.com/AndrejGorodnij)                    | UI                                   |
 | Vietnamese (Tiếng Việt)                     | [7777Hecker](https://github.com/7777Hecker)                            | UI                                   |
+| Bulgarian (Български)                       | [kbkozlev](https://github.com/kbkozlev)                                         | UI and [README](README-Bulgarian.md) |
 
 > Want to add a translation for another language? Update [i18n.js](https://github.com/brentvollebregt/auto-py-to-exe/blob/master/auto_py_to_exe/web/js/i18n.js) and submit a PR or attach it in an issue.
 

--- a/auto_py_to_exe/web/js/i18n.js
+++ b/auto_py_to_exe/web/js/i18n.js
@@ -33,6 +33,7 @@ const translationMap = {
                 vi: 'Vị trí tập lệnh',
                 nl: 'Script Locatie',
                 ko: "스크립트 위치",
+                bg: "Местонахождение на скрипта",
             },
             language: {
                 en: 'Language',
@@ -60,6 +61,7 @@ const translationMap = {
                 vi: 'Ngôn ngữ',
                 nl: 'Taal',
                 ko: "언어",
+                bg: "Език",
             },
             oneFile: {
                 en: 'Onefile',
@@ -87,6 +89,7 @@ const translationMap = {
                 vi: 'Một tập tin',
                 nl: 'Een Bestand',
                 ko: "단일 파일 여부",
+                bg: "Един файл",
             },
             consoleWindow: {
                 en: 'Console Window',
@@ -114,6 +117,8 @@ const translationMap = {
                 vi: 'Cửa sổ bảng điều khiển',
                 nl: 'Console Venster',
                 ko: "콘솔 화면",
+                bg: "Конзолно приложение",
+
             },
             icon: {
                 en: 'Icon',
@@ -141,6 +146,7 @@ const translationMap = {
                 vi: 'Biểu tượng',
                 nl: 'Icoon',
                 ko: "아이콘",
+                bg: "Икона",
             },
             additionalFiles: {
                 en: 'Additional Files',
@@ -168,6 +174,7 @@ const translationMap = {
                 vi: 'Các tệp bổ sung',
                 nl: 'Extra Bestanden',
                 ko: "추가 파일",
+                bg: "Допълнителни Файлове",
             },
             advanced: {
                 en: 'Advanced',
@@ -195,6 +202,7 @@ const translationMap = {
                 vi: 'Trình độ cao',
                 nl: 'Geanvanceerd',
                 ko: "고급",
+                bg: "Разширения",
             },
             settings: {
                 en: 'Settings',
@@ -222,6 +230,7 @@ const translationMap = {
                 vi: 'Cài đặt',
                 nl: 'Instellingen',
                 ko: "설정",
+                bg: "Настройки",
             },
             currentCommand: {
                 en: 'Current Command',
@@ -249,6 +258,7 @@ const translationMap = {
                 vi: 'Lệnh hiện tại',
                 nl: 'Huidig Comando',
                 ko: "현재 명령",
+                bg: "Настояща команда",
             },
             output: {
                 en: 'Output',
@@ -275,6 +285,7 @@ const translationMap = {
                 vi: 'Lối ra',
                 nl: 'Uitvoer',
                 ko: "출력",
+                bg: "Изход",
             },
             specificOptions: {
                 en: `${applicationName} Specific Options`,
@@ -302,6 +313,7 @@ const translationMap = {
                 vi: `${applicationName} Cài đặt chính xác`,
                 nl: `${applicationName} Specifieke Opties`,
                 ko: `${applicationName} 상세 옵션`,
+                bg: `${applicationName} Допълнителни Опции`,
             },
             outputDirectory: {
                 en: 'Output Directory',
@@ -329,6 +341,7 @@ const translationMap = {
                 vi: 'Thư mục đầu ra',
                 nl: 'Uitvoer Pad',
                 ko: "출력 디렉토리",
+                bg: "Изходяща директория",
             },
             increaseRecursionLimit: {
                 en: 'Increase Recursion Limit',
@@ -356,6 +369,7 @@ const translationMap = {
                 vi: 'Tăng giới hạn đệ quy',
                 nl: 'Verhoog Herhaling Limiet',
                 ko: "재귀 한도 증가",
+                bg: "Увеличи лимит на рекурсията",
             },
             manuallyProvideOptions: {
                 en: 'Manually Provide Options',
@@ -383,6 +397,7 @@ const translationMap = {
                 vi: 'Cung cấp cài đặt theo cách thủ công',
                 nl: 'Handmatig Toegestaande Opties',
                 ko: "직접 넣을 옵션",
+                bg: "Ръчно добавени параметри",
             },
             manualArgumentInput: {
                 en: 'Manual Argument Input',
@@ -410,6 +425,7 @@ const translationMap = {
                 vi: 'Nhập thủ công các đối số',
                 nl: 'Manuele Feit Ingave',
                 ko: "직접 입력할 매개변수",
+                bg: "Ръчно добавяне на аргументи",
             },
             configuration: {
                 en: 'Configuration',
@@ -437,6 +453,7 @@ const translationMap = {
                 vi: 'Cấu hình',
                 nl: 'Configuratie',
                 ko: "구성",
+                bg: "Конфигурация",
             }
         },
         button: {
@@ -466,6 +483,7 @@ const translationMap = {
                 vi: 'Xem',
                 nl: 'Zoeken',
                 ko: "찾아보기",
+                bg: "Търсене",
             },
             oneDirectory: {
                 en: 'One Directory',
@@ -493,6 +511,7 @@ const translationMap = {
                 vi: 'Một thư mục',
                 nl: 'Een Map',
                 ko: "단일 디렉토리",
+                bg: "Една директория",
             },
             oneFile: {
                 en: 'One File',
@@ -520,6 +539,7 @@ const translationMap = {
                 vi: 'Một tập tin',
                 nl: 'Een Bestand',
                 ko: "단일 파일",
+                bg: "Един файл",
             },
             consoleBased: {
                 en: 'Console Based',
@@ -547,6 +567,7 @@ const translationMap = {
                 vi: 'Trong bảng điều khiển',
                 nl: 'Console Gebaseerd',
                 ko: "콘솔 기반",
+                bg: "Конзолно приложение",
             },
             windowBased: {
                 en: 'Window Based (hide the console)',
@@ -574,6 +595,7 @@ const translationMap = {
                 vi: 'Trong cửa sổ (ẩn bàn điều khiển)',
                 nl: 'Venster Gebaseerd',
                 ko: "창 기반 (콘솔창 가리기)",
+                bg: "Приложение с прозорец (скриване на конзолата)",
             },
             addFiles: {
                 en: 'Add Files',
@@ -601,6 +623,7 @@ const translationMap = {
                 vi: 'Thêm các tập tin',
                 nl: 'Bestanden Toevoegen',
                 ko: "파일 추가",
+                bg: "Добавяне на файлове",
             },
             addFolder: {
                 en: 'Add Folder',
@@ -628,6 +651,7 @@ const translationMap = {
                 vi: 'Thêm thư mục',
                 nl: 'Map Toevoegen',
                 ko: "폴더 추가",
+                bg: "Добавяне на папки",
             },
             addBlank: {
                 en: 'Add Blank',
@@ -655,6 +679,7 @@ const translationMap = {
                 vi: 'Thêm trống',
                 nl: 'Leeg Toevoegen',
                 ko: "직접 입력",
+                bg: "Добавяне на шаблон",
             },
             importConfig: {
                 en: 'Import Config From JSON File',
@@ -682,6 +707,7 @@ const translationMap = {
                 vi: 'Nhập cấu hình từ tệp JSON',
                 nl: 'Importeer Config Uit JSON Bestand',
                 ko: "JSON 파일에서 구성 가져오기",
+                bg: "Импортиране на конфигурация от JSON файл",
             },
             exportConfig: {
                 en: 'Export Config To JSON File',
@@ -708,6 +734,7 @@ const translationMap = {
                 vi: 'Xuất cấu hình sang tệp JSON',
                 nl: 'Exporteer Config',
                 ko: "JSON 파일에 구성 저장하기",
+                bg: "Експортиране на конфигурация към JSON файл",
             },
             convert: {
                 en: 'Convert .py to .exe',
@@ -735,6 +762,7 @@ const translationMap = {
                 vi: 'Chuyển đổi .py sang .exe',
                 nl: 'Converteer .py naar .exe',
                 ko: ".py에서 .exe로 전환",
+                bg: "Конвертиране на .py към .exe",
             },
             openOutputFolder: {
                 en: 'Open Output Folder',
@@ -762,6 +790,7 @@ const translationMap = {
                 vi: 'Mở thư mục đầu ra',
                 nl: 'Open Uitvoer Map',
                 ko: "출력 폴더 열기",
+                bg: "Отваряне на изходна папка",
             },
             enable: {
                 en: 'Enable',
@@ -789,6 +818,7 @@ const translationMap = {
                 vi: 'Cho phép',
                 nl: 'Ingeschakeld',
                 ko: "활성화",
+                bg: "Включи",
             },
         },
         links: {
@@ -818,6 +848,7 @@ const translationMap = {
                 vi: 'Đăng trợ giúp',
                 nl: 'Help',
                 ko: "도움말",
+                bg: "Помощ",
             }
         },
         placeholders: {
@@ -847,6 +878,7 @@ const translationMap = {
                 vi: 'Đường dẫn tập tin',
                 nl: 'Bestand Pad',
                 ko: "파일 경로",
+                bg: "Път към файла",
             },
             icoFile: {
                 en: '.ico file',
@@ -874,6 +906,7 @@ const translationMap = {
                 vi: 'tập tin .ico',
                 nl: '.ico Bestand',
                 ko: ".ico 파일",
+                bg: ".ico файл",
             },
             directory: {
                 en: 'DIRECTORY',
@@ -901,6 +934,7 @@ const translationMap = {
                 vi: 'THÀNH PHẦN',
                 nl: 'MAP',
                 ko: "디렉토리",
+                bg: "Директория",
             },
             arguments: {
                 en: 'ARGUMENTS',
@@ -928,6 +962,7 @@ const translationMap = {
                 vi: 'TRANH LUẬN',
                 nl: 'ARGUMENTEN',
                 ko: "매개변수",
+                bg: "Аргументи",
             }
         },
         helpText: {
@@ -957,6 +992,7 @@ const translationMap = {
                 vi: 'Thư mục chứa đầu ra. Nó sẽ được tạo ra nếu nó không tồn tại.',
                 nl: 'De uitvoermap. Wordt aangemaakt als de map niet bestaat.',
                 ko: "결과물이 저장될 디렉토리. 디렉토리가 존재하지 않으면 자동 생성됩니다.",
+                bg: "Изходната папка ще бъде създадена, ако не съществува.",
             },
             increaseRecursionLimit: {
                 en: 'Having this enabled will set the recursion limit to 5000 using sys.setrecursionlimit(5000).',
@@ -984,6 +1020,7 @@ const translationMap = {
                 vi: 'Nếu được bật, giới hạn đệ quy được tăng lên 5000 bằng cách sử dụng sys.setrecursionlimit(5000).',
                 nl: 'Indien ingeschakeld, dan is de recurentie limiet beperkt tot 5000 gebruik makend van sys.setrecursionlimit(5000).',
                 ko: "활성화 시 sys.setrecursionlimit(5000)을 사용해 재귀 한도를 5000까지 늘립니다.",
+                bg: "Във включено положение, лимитът на рекурсията ще бъде увеличен до 5000 използвайки sys.setrecursionlimit(5000).",
             },
             manualArgumentInput: {
                 en: 'Inject raw text into the generated command.',
@@ -1011,6 +1048,7 @@ const translationMap = {
                 vi: 'Dán văn bản vào lệnh đã tạo.',
                 nl: 'Voeg rauwe tekst in de gegenereerde commando',
                 ko: "생성된 명령을 입력된 텍스트와 함께 실행합니다",
+                bg: "Добавяне на текст към генерираната команда",
             }
         },
         notes: {
@@ -1040,6 +1078,7 @@ const translationMap = {
                 vi: 'Cảnh báo: tệp này không phải là tệp .ico hợp lệ',
                 nl: 'Waarschuwing: het bestand is geen geldig .ico bestand',
                 ko: "경고: 이 파일은 유효한 .ico 파일이 아닙니다",
+                bg: "Внимание: това не е валиден .ico файл",
             },
             oneFileAdditionalFilesNote: {
                 en: 'Be careful when using additional files with onefile mode;\n' +
@@ -1117,6 +1156,9 @@ const translationMap = {
                 ko: "단일 파일 모드와 추가 파일 모드를 같이 사용할 때 주의해야 합니다.\n" +
                     `<a ${onFileModeAdditionalFilesHelpAnchorTagContents}>이 문서</a>\n` +
                     "를 읽고 PyInstaller 모듈을 사용해 코드를 수정하세요.",
+                bg: "Внимавайте при използването на допълнителни файлове в режим 'един файл'\n" +
+                    `<a ${onFileModeAdditionalFilesHelpAnchorTagContents}>Прочетете това</a>\n` +
+                    'и проверете вашият код за съвместимост с PyInstaller.',
             },
             rootDirectory: {
                 en: 'If you want to put files in the root directory, put a period (.) in the destination.',
@@ -1144,6 +1186,7 @@ const translationMap = {
                 vi: 'Nếu bạn muốn thêm tệp vào thư mục gốc, hãy thêm dấu chấm (.) vào đích.',
                 nl: 'Als je de bestanden wil toevoegen aan de root map, gebruik een punt (.) in de bestemming',
                 ko: '최상위 디렉토리에 파일을 넣으려고 한다면, 경로에 마침표 (.)를 입력하세요.',
+                bg: "Ако желаете да поставите файлове в главната папка сложете (.) в началото на пътя.",
             },
             somethingWrongWithOutput: {
                 en: 'Something wrong with your exe? Read ' +
@@ -1219,6 +1262,9 @@ const translationMap = {
                 ko: 'exe 파일에 문제가 있나요? ' +
                     `<a ${helpPostLinkAnchorTagContents}>자주 발생하는 오류의 수정 방법을 다룬 문서</a>` +
                     '를 읽어서 문제를 해결해보세요',
+                bg: 'Има проблем с вашият .exe файл? Прочетете ' +
+                    `<a ${helpPostLinkAnchorTagContents}>този пост за справка с най-често срещаните проблеми</a>` +
+                    ' и как да ги разрешите.',
             }
         }
     },
@@ -1252,6 +1298,7 @@ const translationMap = {
                 vi: 'Cài đặt đơn giản',
                 nl: 'Algemene Opties',
                 ko: '일반 옵션',
+                bg: "Основни настройки",
             },
             whatToBundleWhereToSearch: {
                 en: 'What to bundle, where to search',
@@ -1279,6 +1326,7 @@ const translationMap = {
                 vi: 'Gói gì, tìm ở đâu',
                 nl: 'Wat samenbrengen, waar te  zoeken',
                 ko: "번들 묶기 옵션 및 검색 옵션",
+                bg: "Какво да бъде включено, къде да бъде намерено",
             },
             howToGenerate: {
                 en: 'How to generate',
@@ -1306,6 +1354,7 @@ const translationMap = {
                 vi: 'Làm thế nào để tạo ra',
                 nl: 'Hoe te genereren',
                 ko: "생성 옵션",
+                bg: "Настройка на генератора",
             },
             windowsAndMacOsXSpecificOptions: {
                 en: 'Windows And macOS X Specific Options',
@@ -1332,6 +1381,7 @@ const translationMap = {
                 vi: 'Cài đặt cụ thể của Windows và macOS X',
                 nl: 'Windows en macOS X Specifieke Opties',
                 ko: "Windows와 macOS X 상세 옵션",
+                bg: "Настройки за macOS X и Windows",
             },
             windowsSpecificOptions: {
                 en: 'Windows specific options',
@@ -1359,6 +1409,7 @@ const translationMap = {
                 vi: 'Cài đặt cụ thể của Windows',
                 nl: 'Windows Specifieke Opties',
                 ko: "Windows 전용 상세 옵션",
+                bg: "Настройки за Windows",
             },
             windowsSideBySideAssemblySearchingOptions: {
                 en: 'Windows Side-by-side Assembly searching options (advanced)',
@@ -1386,6 +1437,7 @@ const translationMap = {
                 vi: 'Windows Side-by-side Cài đặt tìm kiếm hội (nâng cao)',
                 nl: 'Windows Zijde-bij-Zijde Samenvoeging Zoek Opties (geadvanceerd)',
                 ko: "Windows 병렬 어셈블리 검색 옵션 (고급)",
+                bg: "Windows Side-by-side Assembly (разширени)",
             },
             macOsxSpecificOptions: {
                 en: 'macOS X specific options',
@@ -1413,6 +1465,7 @@ const translationMap = {
                 vi: 'Cài đặt cụ thể của macOS X',
                 nl: 'macOS X Specifieke Opties',
                 ko: "macOS X 전용 옵션",
+                bg: "Специфични настройки за macOS X",
             },
             rarelyUsedSpecialOptions: {
                 en: 'Rarely used special options',
@@ -1440,6 +1493,7 @@ const translationMap = {
                 vi: 'Các cài đặt đặc biệt hiếm khi được sử dụng',
                 nl: 'Uitzonderlijk gebruikte opties',
                 ko: "사용이 드문 특수 옵션",
+                bg: "Рядко използвани допълнителни настройки",
             },
             other: {
                 en: 'Other',
@@ -1467,6 +1521,7 @@ const translationMap = {
                 vi: 'Khác',
                 nl: 'Andere',
                 ko: "기타",
+                bg: "Други",
             },
         },
         button: {
@@ -1497,6 +1552,7 @@ const translationMap = {
                 vi: 'Tìm kiếm tập tin',
                 nl: 'Zoeken naar Bestand',
                 ko: "파일 탐색",
+                bg: "Търсене на файл",
             },
             browseForFolder: {
                 en: 'Browse for Folder',
@@ -1524,6 +1580,7 @@ const translationMap = {
                 vi: 'Thư mục tìm kiếm',
                 nl: 'Zoeken naar Map',
                 ko: "폴더 탐색",
+                bg: "Търсене на папка",
             },
             enable: {
                 en: 'Enable',
@@ -1551,6 +1608,7 @@ const translationMap = {
                 vi: 'Bật',
                 nl: 'Inschakelen',
                 ko: "활성화",
+                bg: "Включи",
             },
             disable: {
                 en: 'Disable',
@@ -1578,6 +1636,7 @@ const translationMap = {
                 vi: 'Tắt',
                 nl: 'Uitschakelen',
                 ko: "비활성화",
+                bg: "Изключи",
             },
             converting: {
                 en: 'Converting...',
@@ -1605,6 +1664,7 @@ const translationMap = {
                 vi: 'Chuyển đổi...',
                 nl: 'Omzetten',
                 ko: "변환 중...",
+                bg: "Конвертиране...",
             },
             clearOutput: {
                 en: 'Clear Output',
@@ -1632,6 +1692,7 @@ const translationMap = {
                 vi: 'Xóa đầu ra',
                 nl: 'Wis Uitkomst',
                 ko: "출력 결과 지우기",
+                bg: "Изчистване на изхода",
             },
         },
         modal: {
@@ -1661,6 +1722,7 @@ const translationMap = {
                 vi: 'Ghi đè lên cấu hình hiện tại?',
                 nl: 'Overschrijf huidige configuratie?',
                 ko: "현재 설정을 덮어씌우시겠습니까?",
+                bg: "Презаписване на сегашната конфигурация?",
             },
             configModalDescription: {
                 en: 'All previously inserted values will be erased.',
@@ -1688,6 +1750,7 @@ const translationMap = {
                 vi: 'Tất cả các giá trị trước đó sẽ bị xóa.',
                 nl: 'Alle voorgaande ingegeven waarden worden gewist.',
                 ko: "이전까지 입력된 값이 모두 삭제됩니다.",
+                bg: "Всички предварително зададени параметри ще бъдат изтрити.",
             },
             configModalConfirmButton: {
                 en: 'Confirm',
@@ -1715,6 +1778,7 @@ const translationMap = {
                 vi: 'Xác nhận',
                 nl: 'Bevestig',
                 ko: "확인",
+                bg: "Потвърди",
             },
             configModalCancelButton: {
                 en: 'Cancel',
@@ -1742,6 +1806,7 @@ const translationMap = {
                 vi: 'Hủy bỏ',
                 nl: 'Annuleer',
                 ko: "취소",
+                bg: "Отмяна",
             }
         }
     },
@@ -1774,6 +1839,7 @@ const translationMap = {
                 vi: 'Thiếu không gian tập lệnh.\nVui lòng thêm không gian ở trên.',
                 nl: 'Je hebt de locatie van je script niet opgegeven.\n Voeg deze in bovenaan de pagina.',
                 ko: '스크립트 위치를 지정하지 않았습니다.\n이 페이지 맨 상단에서 위치를 지정하세요.',
+                bg: "Няма зададено местонахождение на скрипта. \nМоля задайте го в горната част на страницата.",
             },
             overwritePreviousOutput: {
                 en: 'This action will overwrite a previous output in the output folder.\nContinue?',
@@ -1801,6 +1867,7 @@ const translationMap = {
                 vi: 'Điều này sẽ ghi đè lên đầu ra trước đó.\nTiếp tục?',
                 nl: 'Deze actie overschrijft de vorige uitkomst in de uitvoer map.\n Doorgaan?',
                 ko: "이 작업은 출력 폴더에 과거의 출력물을 덮어씌웁니다.\n계속하시겠습니까?",
+                bg: "Това действие ще презапише предходният изход в изходната папка. \nИскате ли да продължите?",
             }
         },
     }
@@ -1996,6 +2063,10 @@ const supportedLanguages = [
     {
         name: 'Vietnamese (Tiếng Việt)',
         code: 'vi',
+    },
+        {
+        name: 'Bulgarian (Български)',
+        code: 'bg',
     },
 ];
 

--- a/auto_py_to_exe/web/js/i18n.js
+++ b/auto_py_to_exe/web/js/i18n.js
@@ -1973,6 +1973,10 @@ const supportedLanguages = [
         code: 'pt_br'
     },
     {
+        name: 'Bulgarian (Български)',
+        code: 'bg',
+    },
+    {
         name: 'Chinese Simplified (简体中文)',
         code: 'zh',
     },
@@ -2063,10 +2067,6 @@ const supportedLanguages = [
     {
         name: 'Vietnamese (Tiếng Việt)',
         code: 'vi',
-    },
-        {
-        name: 'Bulgarian (Български)',
-        code: 'bg',
     },
 ];
 

--- a/auto_py_to_exe/web/js/i18n.js
+++ b/auto_py_to_exe/web/js/i18n.js
@@ -118,7 +118,6 @@ const translationMap = {
                 nl: 'Console Venster',
                 ko: "콘솔 화면",
                 bg: "Конзолно приложение",
-
             },
             icon: {
                 en: 'Icon',


### PR DESCRIPTION
**Summary**

I have added a Bulgarian translation

**New feature checklist**

- [x] I have ran the application to make sure my code runs
- [x] This not just a simple formatting change

**Translation checklist**

- [x] I have ran the application to make sure my code runs
- [x] I have used the correct [ISO 639-1 code](https://www.alchemysoftware.com/livedocs/ezscript/Topics/Catalyst/Language.htm) for my translations (e.g. `en`) 
- [x] I have made sure to leave a `,` at the end of each translation added
- [x] I have added the language to `supportedLanguages` in alphabetical order
- [x] I have added the language to the table in README.md in alphabetical order
- [x] (*If you translated the README*) I have translated the README and linked it in the main README.md
