### PR TITLE
Use argparse.ArgumentParser "version" action

### DIFF
--- a/auto_py_to_exe/__main__.py
+++ b/auto_py_to_exe/__main__.py
@@ -4,10 +4,10 @@ import os
 import shutil
 import tempfile
 
-from . import shims
+from . import shims, __version__
+
 shims.install_shims()
 
-from . import __version__
 from . import config
 from . import validation
 from . import ui
@@ -95,9 +95,7 @@ def run():
         default='ERROR'
     )
     parser.add_argument(
-        "--version",
-        action="store_true",
-        help="print the version - will not run the ui"
+        "-v", "--version", action="version", version=f"auto-py-to-exe {__version__}"
     )
     args = parser.parse_args()
 
@@ -118,12 +116,8 @@ def run():
     if (args.build_directory_override is not None) and (not os.path.isdir(args.build_directory_override)):
         raise ValueError("--build-directory-override must be a directory")
 
-    # If the user has asked for the version, print it, otherwise run the application
-    if args.version:
-        print('auto-py-to-exe ' + __version__)
-    else:
-        logging_level = getattr(logging, args.logging_level)
-        start_ui(logging_level, args.build_directory_override)
+    logging_level = getattr(logging, args.logging_level)
+    start_ui(logging_level, args.build_directory_override)
 
 
 if __name__ == '__main__':

--- a/auto_py_to_exe/__main__.py
+++ b/auto_py_to_exe/__main__.py
@@ -4,13 +4,14 @@ import os
 import shutil
 import tempfile
 
-from . import shims, __version__
+from . import shims
 
 shims.install_shims()
 
 from . import config
 from . import validation
 from . import ui
+from . import  __version__
 
 
 def start_ui(logging_level, build_directory_override):


### PR DESCRIPTION
**Revert code formatting changes made with black**

**New feature checklist**

- [x] I have ran the application to make sure my code runs
- [x] This not just a simple formatting change

**Translation checklist**

- [ ] I have ran the application to make sure my code runs
- [ ] I have used the correct [ISO 639-1 code](https://www.alchemysoftware.com/livedocs/ezscript/Topics/Catalyst/Language.htm) for my translations (e.g. `en`) 
- [ ] I have made sure to leave a `,` at the end of each translation added
- [ ] I have added the language to `supportedLanguages` in alphabetical order
- [ ] I have added the language to the table in README.md in alphabetical order
- [ ] (*If you translated the README*) I have translated the README and linked it in the main README.md
