### PR TITLE
Fix Turkish translation errors in README-Turkish.md

### DIFF
--- a/README-Turkish.md
+++ b/README-Turkish.md
@@ -32,13 +32,13 @@ Suomenkieliset käyttöohjeet löydät [täältä](./README-Finnish.md)
 
 - Python : 3.6-3.12
 
-_Görsellerde gösterilen arayüze sahip olmak için kroma ihtiyacınız olacak. chrome kurulu değilse veya --default-browser sağlanmışsa, varsayılan tarayıcı kullanılacaktır._
+_Görsellerde gösterilen arayüze sahip olmak için Chrome tabanlı bir tarayıcıya ihtiyacınız olacak. Chrome kurulu değilse veya --default-browser parametresi sağlanmışsa, varsayılan tarayıcı kullanılacaktır._
 
-> [PyInstaller 4.0](https://github.com/pyinstaller/pyinstaller/releases/tag/v4.0) itibariyle, Python 2.7 artık desteklenmemektedir. Bu aracın Python 2.7 ile nasıl kullanılacağına ilişkin adımlar için aşağıdaki "[Python 2.7 Destek](#python-27-destek)" bölümünü okuyun.
+> [PyInstaller 4.0](https://github.com/pyinstaller/pyinstaller/releases/tag/v4.0) itibarıyla, Python 2.7 artık desteklenmemektedir. Bu aracın Python 2.7 ile nasıl kullanılacağına ilişkin adımlar için aşağıdaki "[Python 2.7 Desteği](#python-27-destek)" bölümünü okuyun.
 
-### Yükleme ve Kullanım
+### Kurulum ve Kullanım
 
-#### [PyPI](https://pypi.org/project/auto-py-to-exe/) Yoluyla Kurulum
+#### [PyPI](https://pypi.org/project/auto-py-to-exe/) Aracılığıyla Kurulum
 
 Bu projeyi PyPI kullanarak kurabilirsiniz:
 
@@ -46,7 +46,7 @@ Bu projeyi PyPI kullanarak kurabilirsiniz:
 $ pip install auto-py-to-exe
 ```
 
-Ardından çalıştırmak için terminalde aşağıdakileri yürütün:
+Ardından çalıştırmak için terminalde aşağıdaki komutu yürütün:
 
 ```
 $ auto-py-to-exe
@@ -54,7 +54,7 @@ $ auto-py-to-exe
 
 > Python'un birden fazla sürümü kuruluysa, `auto-py-to-exe` yerine `python -m auto_py_to_exe` kullanabilirsiniz.
 
-### [GitHub](https://github.com/brentvollebregt/auto-py-to-exe) aracılığı ile Yükleme
+### [GitHub](https://github.com/brentvollebregt/auto-py-to-exe) Aracılığıyla Kurulum
 
 ```
 $ git clone https://github.com/brentvollebregt/auto-py-to-exe.git
@@ -62,33 +62,33 @@ $ cd auto-py-to-exe
 $ python setup.py install
 ```
 
-Ardından çalıştırmak için terminalde aşağıdakileri yürütün:
+Ardından çalıştırmak için terminalde aşağıdaki komutu yürütün:
 
 ```
 $ auto-py-to-exe
 ```
 
-#### [Github](https://github.com/brentvollebregt/auto-py-to-exe) Üzerinden Yerel Olarak Çalıştırma (yükleme olmadan)
+#### [Github](https://github.com/brentvollebregt/auto-py-to-exe) Üzerinden Yerel Olarak Çalıştırma (kurulum olmadan)
 
 Aşağıdaki adımları izleyerek bu projeyi yerel olarak çalıştırabilirsiniz:
 
-1. [repoyu] kopyalayın/indirin(https://github.com/brentvollebregt/auto-py-to-exe)
-2. Projeye cmd/terminal ve cd'yi açın.
-3. `python -m pip install -r requirements.txt` uygulayın.
+1. [Repoyu](https://github.com/brentvollebregt/auto-py-to-exe) klonlayın/indirin
+2. Projeye cmd/terminal açın ve cd ile girin.
+3. `python -m pip install -r requirements.txt` komutunu çalıştırın.
 
-Şimdi uygulamayı çalıştırmak için `python -m auto_py_to_exe` yürütün. Proje içinde çalışırken uygulama modunda bir Chrome penceresi açılır.
+Şimdi uygulamayı çalıştırmak için `python -m auto_py_to_exe` komutunu yürütün. Proje içinde çalışırken uygulama modunda bir Chrome penceresi açılır.
 
-> 'python -m auto_py_to_exe'yi çağırırken auto_py_to_exe altındaki dizinde olduğunuzdan emin olun (3. adımdan sonra olacaksınız) yoksa auto_py_to_exe klasörüne kesinlikle/nispeten o anda bulunduğunuz yere başvurmanız gerekir.
+> `python -m auto_py_to_exe` komutunu çağırırken auto_py_to_exe dizininde bulunduğunuzdan emin olun (3. adımdan sonra burada olacaksınız), aksi takdirde auto_py_to_exe klasörüne mutlak/göreli yol ile başvurmanız gerekir.
 
 ## Uygulamayı Kullanma
 
 1. Betik konumunuzu seçin. (yapıştırın veya bir dosya gezgini kullanın)
-   - Dosya mevcut olduğunda anahat mavi olur.
-2. Diğer seçenekleri belirleyin ve simge veya diğer dosyalar gibi şeyler ekleyin.
+   - Dosya mevcut olduğunda çerçeve mavi olur.
+2. Diğer seçenekleri belirleyin ve ikon veya diğer dosyalar gibi şeyler ekleyin.
 3. Dönüştürmek için alttaki büyük mavi düğmeye tıklayın.
 4. Tamamlandığında dönüştürülen dosyalarınızı /output içinde bulabilirsiniz.
 
-_Bu kadar Kolay._
+_Bu kadar kolay._
 
 ### Argümanlar
 
@@ -99,18 +99,18 @@ Kullanım: `auto-py-to-exe [-db] [-c [CONFIG]] [-o [PATH]] [filename]`
 | filename                                                     | konumsal/opsiyonel | Kullanıcı arayüzündeki "Komut Dosyası Konumu" alanını önceden doldurun.                                                                                                      |
 | -db, --default-browser                                       | opsiyonel          | Varsayılan tarayıcıyı (Chrome olabilir) kullanarak kullanıcı arayüzünü kalemleyin. Chrome'u bulmaya çalışmaz.                                                                |
 | -nu, --no-ui                                                 | opsiyonel          | Kullanıcı arayüzünü bir tarayıcıda açmaya çalışmayın ve uygulamanın erişilebileceği adresi yazdırın.                                                                         |
-| -c [CONFIG], --config [CONFIG]                               | opsiyonel          | Kullanıcı arabirimini önceden doldurmak için bir yapılandırma dosyası (json) sağlayın. Bunlar ayarlar sekmesinde oluşturulabilir.                                            |
-| -o [PATH], --output-dir [PATH]                               | opsiyonel          | Varsayılan çıkış dizinini ayarlayın. Bu, kullanıcı arayüzünde hala değiştirilebilir.                                                                                         |
-| -bdo [FOLDER_PATH], --build-directory-override [FOLDER_PATH] | opsiyonel          | Varsayılan derleme dizinini geçersiz kılın. Virüsten koruma programınızın dosyaları kaldırmasını durdurmak için bir klasörü beyaz listeye almanız gerekiyorsa kullanışlıdır. |
+| -c [CONFIG], --config [CONFIG]                               | opsiyonel          | Kullanıcı arayüzünü önceden doldurmak için bir yapılandırma dosyası (json) sağlayın. Bunlar ayarlar sekmesinde oluşturulabilir.                                            |
+| -o [PATH], --output-dir [PATH]                               | opsiyonel          | Varsayılan çıktı dizinini ayarlayın. Bu, kullanıcı arayüzünde hala değiştirilebilir.                                                                                         |
+| -bdo [FOLDER_PATH], --build-directory-override [FOLDER_PATH] | opsiyonel          | Varsayılan derleme dizinini geçersiz kılın. Antivirüs programınızın dosyaları kaldırmasını durdurmak için bir klasörü beyaz listeye almanız gerekiyorsa kullanışlıdır. |
 | -lang [LANGUAGE_CODE], --language [LANGUAGE_CODE]            | opsiyonel          | Kullanıcı arayüzüne, açarken varsayılan olarak hangi dili kullanması gerektiği konusunda ipucu verin. Dil kodları aşağıdaki "Çeviriler" altındaki tabloda bulunabilir.       |
 
-> Bu paketi yerel olarak çalıştırıyorsanız, `auto-py-to-exe` yerine `python -m auto_py_to_exe` çağırmanız gerekecektir.
+> Bu paketi yerel olarak çalıştırıyorsanız, `auto-py-to-exe` yerine `python -m auto_py_to_exe` komutunu çağırmanız gerekecektir.
 
 ### JSON Yapılandırması
 
-Aynı verileri kullanıcı arayüzüne tekrar tekrar eklemek yerine, ayarlar sekmesindeki "Yapılandırma" bölümüne gidip yapılandırmayı bir JSON dosyasına aktararak mevcut durumu dışa aktarabilirsiniz. Bu, daha sonra tüm alanları yeniden doldurmak için kullanıcı arayüzüne tekrar aktarılabilir.
+Aynı verileri kullanıcı arayüzüne tekrar tekrar eklemek yerine, ayarlar sekmesindeki "Yapılandırma" bölümüne gidip yapılandırmayı bir JSON dosyasına aktararak mevcut durumu dışa aktarabilirsiniz. Bu, daha sonra tüm alanları yeniden doldurmak için kullanıcı arayüzüne tekrar içe aktarılabilir.
 
-Ana bilgisayarların taşınması farklı dizin yapıları anlamına gelebileceğinden, bu JSON yapılandırma dışa aktarma işlemi çıkış dizinini otomatik olarak kaydetmez. Çıkış dizininin JSON yapılandırmasında olmasını istiyorsanız, dizini JSON dosyasındaki "nonPyinstallerOptions.outputDirectory" altına ekleyin (yeni bir anahtar oluşturmanız gerekir).
+Bilgisayarların taşınması farklı dizin yapıları anlamına gelebileceğinden, bu JSON yapılandırma dışa aktarma işlemi çıktı dizinini otomatik olarak kaydetmez. Çıktı dizininin JSON yapılandırmasında olmasını istiyorsanız, dizini JSON dosyasındaki "nonPyinstallerOptions.outputDirectory" altına ekleyin (yeni bir anahtar oluşturmanız gerekir).
 
 ## Video
 
@@ -119,17 +119,17 @@ Başlamanıza yardımcı olacak görsel bir şeye ihtiyacınız varsa, [Bu proje
 ## Aracı Kullanmayla İlgili Sorunlar
 
 Paketlenmiş yürütülebilir dosyayla ilgili sorun yaşıyorsanız veya genel olarak bu aracı kullanıyorsanız,
-[auto-py-to-exe kullanırken sık karşılaşılan sorunlar hakkındaki blog yazımı (İngilizce)](https://nitratine.net/blog/post/issues-when-using-auto-py-to-exe/?utm_source=auto_py_to_exe&utm_medium=readme_link&utm_campaign=auto_py_to_exe_help) okumanızı tavsiye ederim. Bu gönderi, Python betiklerini paketleme hakkında bilmeniz gereken şeyleri ve genellikle yanlış giden şeyler için düzeltmeleri kapsar.
+[auto-py-to-exe kullanırken sık karşılaşılan sorunlar hakkındaki blog yazımı (İngilizce)](https://nitratine.net/blog/post/issues-when-using-auto-py-to-exe/?utm_source=auto_py_to_exe&utm_medium=readme_link&utm_campaign=auto_py_to_exe_help) okumanızı tavsiye ederim. Bu yazı, Python betiklerini paketleme hakkında bilmeniz gereken şeyleri ve genellikle yanlış giden şeyler için çözümleri kapsar.
 
-Bu araçla ilgili bir sorun bulduğunuzu düşünüyorsanız, lütfen [bir sorun oluşturun (İngilizce)](https://github.com/brentvollebregt/auto-py-to-exe/issues/new/choose) ("Başlayın"ı tıklayın) ) ve "Hata raporu" seçeneği tarafından sağlanan şablonu doldurun. Sorununuz yalnızca başvurunuzla ilişkiliyse, lütfen bu havuzda bir sorun oluşturmayın - bunun yerine yardım gönderisine, videoya yorum yapın veya yeni bir tartışma oluşturun.
+Bu araçla ilgili bir sorun bulduğunuzu düşünüyorsanız, lütfen [bir sorun bildirimi oluşturun (İngilizce)](https://github.com/brentvollebregt/auto-py-to-exe/issues/new/choose) "Bug report" seçeneği tarafından sağlanan şablonu doldurun. Sorununuz yalnızca uygulamanızla ilgiliyse, lütfen bu depoda bir sorun bildirimi oluşturmayın - bunun yerine yardım gönderisine, videoya yorum yapın veya yeni bir tartışma oluşturun.
 
-> Şablonu doldururken, neler olduğunu net bir şekilde açıkladığınızdan, çoğaltma adımlarını ve bir [minimum tekrarlanabilir örnek (İngilizce)](https://stackoverflow.com/help/minimal-reproducible-example) verdiğinizden ve olması gerektiğine inandığınız şeyi açıkladığınızdan emin olun. . Bunlar olmadan, sorunu belirlemek daha uzun sürecektir.
+> Şablonu doldururken, neler olduğunu açık bir şekilde belirttiğinizden, sorunu yeniden oluşturma adımlarını paylaştığınızdan ve bir [minimal tekrarlanabilir örnek (İngilizce)](https://stackoverflow.com/help/minimal-reproducible-example) sunduğunuzdan emin olun. Ayrıca beklediğiniz sonucun ne olduğunu da açıklayın. Bu bilgiler olmadan sorununuzu çözmek daha uzun zaman alacaktır.
 
-## Python 2.7 Destek
+## Python 2.7 Desteği
 
 9 Ağustos 2020'de yayınlanan [PyInstaller v4.0](https://github.com/pyinstaller/pyinstaller/releases/tag/v4.0) itibarıyla Python 2.7 artık desteklenmemektedir; PyInstaller'ın daha eski bir sürümünü yükleyerek bu aracı Python 2.7 ile kullanmaya devam edebilirsiniz. [PyInstaller v3.6](https://github.com/pyinstaller/pyinstaller/releases/tag/v3.6), Python 2.7'yi destekleyen son sürümdü; bunu yüklemek için önce PyInstaller'ın mevcut sürümlerini kaldırın ve ardından "python -m pip install pyinstaller==3.6" komutunu çalıştırın.
 
-## Test yapmak
+## Test
 
 Testler `/tests` içinde bulunur ve pytest kullanılarak çalıştırılır:
 
@@ -139,7 +139,7 @@ $ pip install -e .
 $ pytest
 ```
 
-## Screenshots
+## Ekran Görüntüleri
 
 | <!-- -->                                                                                                                                             | <!-- -->                                                                                                                              |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This PR addresses various Turkish language issues in the README-Turkish.md file to improve readability and accuracy:

- Fixed grammatical errors and awkward phrasing throughout the document ("krom" --> "chrome")
- Corrected technical terminology translations (e.g., "çıkış dizini" → "çıktı dizini")
- Improved sentence structure and flow for better understanding
- Simplified "Troubleshoot" section informations.