### PR TITLE
Fix file type filter for Python files

### DIFF
--- a/auto_py_to_exe/dialogs.py
+++ b/auto_py_to_exe/dialogs.py
@@ -37,7 +37,7 @@ def ask_file(file_type):
         file_path = askopenfilename()
     else:
         if file_type == "python":
-            file_types = [("Python files", "*.py;*.pyw"), ("All files", "*")]
+            file_types = [("Python files", "*.py *.pyw"), ("All files", "*")]
         elif file_type == "icon":
             file_types = [("Icon files", "*.ico"), ("All files", "*")]
         elif file_type == "json":


### PR DESCRIPTION
Corrects the file type filter for Python files in the file selection dialog.

The previous filter separated the .py and .pyw extensions, preventing the selection of both file types simultaneously. This change updates the filter to allow either .py or .pyw files to be selected.

Fixes #544