### PR TITLE
Reject file paths used as packaging output directories

### DIFF
--- a/auto_py_to_exe/packaging.py
+++ b/auto_py_to_exe/packaging.py
@@ -72,6 +72,9 @@ def will_packaging_overwrite_existing(file_path: str, manual_name: Optional[str]
 
 def __move_package(src, dst):
     """Move the output package to the desired path (default is output/ - set in script.js)"""
+    if os.path.exists(dst) and not os.path.isdir(dst):
+        raise NotADirectoryError(f"Output path is not a directory: {dst}")
+
     # Make sure the destination exists
     if not os.path.exists(dst):
         os.makedirs(dst)
@@ -143,6 +146,7 @@ def package(pyinstaller_command, options):
         except:  # noqa: E722
             logger.error("Failed to move project")
             logger.exception(traceback.format_exc())
+            return False
     else:
         logger.info("Project output will not be moved to output folder")
         return False

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,6 +3,7 @@ import subprocess
 
 from helpers import PythonScriptAsFile, TemporaryDirectory, os_allow
 
+import auto_py_to_exe.packaging as packaging_module
 from auto_py_to_exe import config as auto_py_to_exe_config
 from auto_py_to_exe.packaging import package
 
@@ -30,3 +31,28 @@ def test_basic_packaging():
                 predicted_exe_location = os.path.join(predicted_output_folder, filename.split(".")[0] + ".exe")
                 exe_output = subprocess.check_output([predicted_exe_location], cwd=predicted_output_folder)
                 assert exe_output == b"Test\r\n"
+
+
+def test_packaging_fails_when_output_cannot_be_moved(tmp_path, monkeypatch):
+    """A failed move must not be reported as a successful package."""
+    build_directory = tmp_path / "build"
+    build_directory.mkdir()
+    auto_py_to_exe_config.temporary_directory = str(build_directory)
+
+    output_directory = tmp_path / "output"
+    output_directory.write_text("not a directory")
+
+    def fake_pyinstaller(_args):
+        dist_directory = build_directory / "application"
+        dist_directory.mkdir()
+        (dist_directory / "built-artifact").write_text("built")
+
+    monkeypatch.setattr(packaging_module, "run_pyinstaller", fake_pyinstaller)
+
+    success = package(
+        "pyinstaller",
+        {"increaseRecursionLimit": False, "outputDirectory": str(output_directory)},
+    )
+
+    assert not success
+    assert output_directory.read_text() == "not a directory"


### PR DESCRIPTION
## Summary

An existing file passed as the packaging output path was treated as a directory. The move step could overwrite that file with the built artifact, and `package()` still returned success.

This change:

- rejects an existing non-directory output path
- returns `False` when moving the built package fails
- adds a regression test that checks the failure result and preserves the existing file

## Testing

- `python -m pytest -q tests/test_packaging.py` passed: 2 passed
- `uvx --from ruff ruff check --select I auto_py_to_exe/packaging.py tests/test_packaging.py` passed
- `git diff --check` passed
- `python -m pytest -q` remains blocked by missing optional environment dependencies: `bottle` and `eel` (2 failed, 3 passed)
